### PR TITLE
OpenmrsGciBotApplication.java: programmatically set tomcat port

### DIFF
--- a/src/main/java/org/openmrs/bot/openmrsgcibot/OpenmrsGciBotApplication.java
+++ b/src/main/java/org/openmrs/bot/openmrsgcibot/OpenmrsGciBotApplication.java
@@ -1,8 +1,10 @@
 package org.openmrs.bot.openmrsgcibot;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.context.annotation.Bean;
 
 import java.io.IOException;
@@ -10,6 +12,9 @@ import java.io.InputStream;
 
 @SpringBootApplication
 public class OpenmrsGciBotApplication {
+
+	@Value("${PORT}")
+	private String tomcatPort;
 
 	public static void main(String[] args) {
 		SpringApplication.run(OpenmrsGciBotApplication.class, args);
@@ -21,5 +26,12 @@ public class OpenmrsGciBotApplication {
 		final InputStream in = this.getClass().getResourceAsStream("/config.json");
 		final Config config = mapper.readValue(in, Config.class);
 		return config;
+	}
+
+	@Bean
+	public EmbeddedServletContainerCustomizer containerCustomizer() {
+		return container -> {
+			container.setPort(Integer.valueOf(tomcatPort));
+		};
 	}
 }


### PR DESCRIPTION
This is to fix the port binding error when app is packaged as container
and deployed to heroku. Heroku does not obey the docker EXPOSE command
in docker file and dynamically assigns a port number to deployed docker
webapps. Spring boot defaults to 8080 but heroku expects a different port
number and it's set in an environment variable $PORT. To fix this, we just
modify default tomcat port by setting it to the $PORT value

Closes https://github.com/ivange94/openmrs-gci-bot/issues/2